### PR TITLE
Mps and cpu device fix

### DIFF
--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -148,7 +148,7 @@ class ChatterboxTTS:
         ckpt_dir = Path(ckpt_dir)
 
         # Always load to CPU first for non-CUDA devices to handle CUDA-saved models
-        if device in ["cpu", "mps"]:
+        if str(device) in ["cpu", "mps"]:
             map_location = torch.device('cpu')
         else:
             map_location = None

--- a/src/chatterbox/vc.py
+++ b/src/chatterbox/vc.py
@@ -57,7 +57,7 @@ class ChatterboxVC:
         ckpt_dir = Path(ckpt_dir)
         
         # Always load to CPU first for non-CUDA devices to handle CUDA-saved models
-        if device in ["cpu", "mps"]:
+        if str(device) in ["cpu", "mps"]:
             map_location = torch.device('cpu')
         else:
             map_location = None


### PR DESCRIPTION
Use string representation of torch device to prevent trying to load with CUDA on non-CUDA systems.

Currently, if you try to run inference with mps or cpu, the torch.device is being checked against the string version of the devices. This causes the code to set None as the map_location (which causes an error on non-CUDA systems (relevant issue: https://github.com/wildminder/ComfyUI-Chatterbox/issues/3))